### PR TITLE
UPDATE: wrap toc mdast elements with details and summery tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.d.ts
 *.log
 yarn.lock
+**/.idea/*

--- a/index.js
+++ b/index.js
@@ -28,9 +28,35 @@ export default function remarkToc(options = {}) {
       return
     }
 
+    // Get the table of content's headings.
+    const toc_summary = node.children[result.index - 1]
+
+    /*
+    * Remove the retrieved heading mdast elements from
+    * their current location and place them inside the summary element.
+    */
+    node.children.splice(result.index - 1, 1)
+
     node.children = [
-      ...node.children.slice(0, result.index),
+      ...node.children.slice(0, result.index - 1),
+      {
+        type: 'html',
+        value: '<details>'
+      },
+      {
+        type: 'html',
+        value: '<summary>'
+      },
+      toc_summary,
+      {
+        type: 'html',
+        value: '</summary>'
+      },
       result.map,
+      {
+        type: 'html',
+        value: '</details>'
+      },
       ...node.children.slice(result.endIndex)
     ]
   }


### PR DESCRIPTION
The npm package remark-toc generates a table of contents for a markdown article based on specified heading elements.

 By default, the table of contents is created as a list immediately following the specified headings.

 However, I want to make the table of contents collapsible. 

To achieve this, I modified the HTML output to place the heading content inside a summary element of a details element, and parallel to it, place the table of contents generated by the remark-toc package.